### PR TITLE
aref error handling

### DIFF
--- a/src/aref.lisp
+++ b/src/aref.lisp
@@ -4,17 +4,12 @@
   ((axis  :initarg :axis)
    (valid :initarg :valid :initform nil))
   (:report (lambda (c s)
-             (with-slots (axis abstract-arrays::index valid) c
+             (with-slots (axis index valid) c
                (format s "Invalid index ~A for array axis of length ~A."
-                       abstract-arrays::index axis)
+                       index axis)
                (when valid
                  (format s "~%Valid index range is from ~A to ~A (both inclusive)."
                          (car valid) (cdr valid)))))))
-
-(define-condition invalid-index (error)
-  ((index :accessor index :initarg :index))
-  (:report (lambda (condition stream)
-             (format stream "Index ~S is invalid" (index condition)))))
 
 (defun array= (array1 array2 &key (test #'equalp))
   "Returns non-NIL if each element of ARRAY1 is equal to each corresponding
@@ -87,7 +82,7 @@ and tests for their equality."
                               (push (the-size (+ o offset-carry (the-int-index (* start s))))
                                     new-offsets)
                               (setq offset-carry 0)))
-                           (t (error 'invalid-index :index ss))))
+                           (t (error 'invalid-array-index :array array :index ss))))
                    (setq dim        (cdr dim)
                          strides    (cdr strides)
                          subscripts (cdr subscripts)

--- a/src/aref.lisp
+++ b/src/aref.lisp
@@ -4,9 +4,9 @@
   ((axis  :initarg :axis)
    (valid :initarg :valid :initform nil))
   (:report (lambda (c s)
-             (with-slots (axis index valid) c
+             (with-slots (axis abstract-arrays::index valid) c
                (format s "Invalid index ~A for array axis of length ~A."
-                       index axis)
+                       abstract-arrays::index axis)
                (when valid
                  (format s "~%Valid index range is from ~A to ~A (both inclusive)."
                          (car valid) (cdr valid)))))))
@@ -38,7 +38,7 @@ and tests for their equality."
     (declare (type int-index normalized-index))
     (if (and (<= 0 normalized-index) (< normalized-index dimension))
         (the-size normalized-index)
-        (error 'invalid-axis-index-error :index index :axis dimension
+        (error 'invalid-array-index-for-axis :index index :axis dimension
                :valid (cons (- dimension) (1- dimension))))))
 
 (defun %aref-view (array &rest subscripts)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -72,7 +72,8 @@
                                #:storage
                                #:dimensions
                                #:rank
-                               #:element-type)
+                               #:element-type
+                               #:index)
        (:import-from #:trivial-types
                      #:function-designator)
        (:local-nicknames


### PR DESCRIPTION
This contains 2 commits that
1. fix bugs in aref error handling
2. reuse invalid-index condition and use existing abstract-arrays:invalid-array-index. I think invalid-index is a duplicate, but feel free to drop this commit if I missed something!

Thanks for your amazing work at bringing numerical computing to Common Lisp :)