### PR TITLE
[add] use single number for array-offset

### DIFF
--- a/optim/aref.lisp
+++ b/optim/aref.lisp
@@ -50,23 +50,10 @@
                                         `(%dense-array ,elt-type ,rank)))
              (subscript-types (mapcar (lm form (primary-form-type form env)) subscripts))
              (ds              (make-gensym-list (length subscripts) "DIMENSION"))
-             (os              (make-gensym-list (length subscripts) "OFFSET"))
              (ss              (make-gensym-list (length subscripts) "STRIDE"))
              (optim-expansion
                (once-only (array)
                  (cond
-                   ((eql rank 0)
-                    `(locally (declare (type dense-array ,array))
-                       ,(when (not safety-zero-p)
-                          `(when (not (and ,@(mapcar (lm d s `(<= 0 ,s (1- ,d)))
-                                                     ds subscripts)))
-                             (error 'invalid-array-index
-                                    :array ,array :index (list ,@subscripts)
-                                    :suggestion
-                                    "Did you mean to use DENSE-ARRAYS:AREF* ?")))
-                       (,storage-accessor
-                        (the ,storage-type (array-storage ,array))
-                        0)))
                    (simple-p
                     `(locally (declare (type dense-array ,array))
                        (destructuring-lists ((int-index ,ss (array-strides ,array)
@@ -83,14 +70,12 @@
                          (,storage-accessor
                           (the ,storage-type (array-storage ,array))
                           (the-int-index (+ ,@(mapcar (lm ss sub
-                                                          `(the-size
+                                                          `(the-int-index
                                                             (* ,ss ,sub)))
                                                       ss subscripts)))))))
                    (t
                     `(locally (declare (type dense-array ,array))
-                       (destructuring-lists ((size      ,os (array-offsets ,array)
-                                                        :dynamic-extent nil)
-                                             (size      ,ds (narray-dimensions ,array)
+                       (destructuring-lists ((size      ,ds (narray-dimensions ,array)
                                                         :dynamic-extent nil)
                                              (int-index ,ss (array-strides ,array)
                                                         :dynamic-extent nil))
@@ -103,10 +88,11 @@
                                       "Did you mean to use DENSE-ARRAYS:AREF* ?")))
                          (,storage-accessor
                           (the ,storage-type (array-storage ,array))
-                          (the-size (+ ,@os ,@(mapcar (lm ss sub
-                                                          `(the-size
-                                                            (* ,ss ,sub)))
-                                                      ss subscripts)))))))))))
+                          (the-size (+ (the-size (array-offset ,array))
+                                       ,@(mapcar (lm ss sub
+                                                     `(the-int-index
+                                                       (* ,ss ,sub)))
+                                                 ss subscripts)))))))))))
           (return-from aref
             (cond ((eq '* elt-type)
                    (signal 'element-type-failure :form array :form-type array-type)
@@ -162,29 +148,11 @@
              (subscript-types (mapcar (lm form (primary-form-type form env)) subscripts))
              (new-value-type  (primary-form-type new-value env))
              (ds              (make-gensym-list (length subscripts) "DIMENSION"))
-             (os              (make-gensym-list (length subscripts) "OFFSET"))
              (ss              (make-gensym-list (length subscripts) "STRIDE"))
              (safety-zero-p (zerop (policy-quality 'safety env)))
              (optim-expansion
                (once-only (array)
                  (cond
-                   ((eql rank 0)
-                    `(locally (declare (type dense-array ,array))
-                       (destructuring-lists ((int-index ,ss (array-strides ,array)
-                                                        :dynamic-extent nil)
-                                             (size      ,ds (narray-dimensions ,array)
-                                                        :dynamic-extent nil))
-                         ,(when (not safety-zero-p)
-                            `(when (not (and ,@(mapcar (lm d s `(<= 0 ,s (1- ,d)))
-                                                       ds subscripts)))
-                               (error 'invalid-array-index
-                                      :array ,array :index (list ,@subscripts)
-                                      :suggestion
-                                      "Did you mean to use (SETF DENSE-ARRAYS:AREF*) ?")))
-                         (setf (,storage-accessor
-                                (the ,storage-type (array-storage ,array))
-                                0)
-                               (the ,elt-type ,new-value)))))
                    (simple-p
                     `(locally (declare (type dense-array ,array))
                        (destructuring-lists ((int-index ,ss (array-strides ,array)
@@ -201,15 +169,13 @@
                          (setf (,storage-accessor
                                 (the ,storage-type (array-storage ,array))
                                 (the-int-index (+ ,@(mapcar (lm ss sub
-                                                                `(the-size
+                                                                `(the-int-index
                                                                   (* ,ss ,sub)))
                                                             ss subscripts))))
                                (the ,elt-type ,new-value)))))
                    (t
                     `(locally (declare (type dense-array ,array))
-                       (destructuring-lists ((size      ,os (array-offsets ,array)
-                                                        :dynamic-extent nil)
-                                             (size      ,ds (narray-dimensions ,array)
+                       (destructuring-lists ((size      ,ds (narray-dimensions ,array)
                                                         :dynamic-extent nil)
                                              (int-index ,ss (array-strides ,array)
                                                         :dynamic-extent nil))
@@ -222,9 +188,9 @@
                                       "Did you mean to use (SETF DENSE-ARRAYS:AREF*) ?")))
                          (setf (,storage-accessor
                                 (the ,storage-type (array-storage ,array))
-                                (the-size (+ ,@os
+                                (the-size (+ (the-size (array-offset ,array))
                                              ,@(mapcar (lm ss sub
-                                                           `(the-size
+                                                           `(the-int-index
                                                              (* ,ss ,sub)))
                                                        ss subscripts))))
                                (the ,elt-type ,new-value)))))))))

--- a/plus/lite.lisp
+++ b/plus/lite.lisp
@@ -11,7 +11,7 @@
    #:storage-accessor
    #:dense-array
    #:simple-dense-array
-   #:array-offsets
+   #:array-offset
    #:array-strides
    #:array-root-array)
   (:import-from
@@ -122,24 +122,22 @@
                  (t (asarray array-like)))))
     (declare (type dense-array array)
              (optimize speed))
-    (multiple-value-bind (dimensions strides offsets)
+    (multiple-value-bind (dimensions strides)
         (if axes
             (loop :for i :of-type size :below (array-rank array)
                   :for axis :in axes
                   :collect (array-dimension array axis) :into dimensions
                   :collect (array-stride array axis) :into strides
-                  :collect (array-offset array axis) :into offsets
-                  :finally (return (values dimensions strides offsets)))
+                  :finally (return (values dimensions strides)))
             (values (reverse (narray-dimensions array))
-                    (reverse (array-strides    array))
-                    (reverse (array-offsets    array))))
+                    (reverse (array-strides    array))))
       (make-instance (class-of array)
                      :storage (array-displaced-to array)
                      :element-type (array-element-type array)
                      :layout (array-layout array)
                      :dimensions dimensions
                      :strides strides
-                     :offsets offsets
+                     :offset (array-offset array)
                      :total-size (array-total-size array)
                      :rank (array-rank array)
                      :root-array (or (dense-arrays::dense-array-root-array array)
@@ -355,7 +353,7 @@ creating the new array and instead return a view instead. "
                             :dimensions new-shape
                             :strides
                             (dense-arrays::dimensions->strides new-shape (array-layout array))
-                            :offsets (make-list (length new-shape) :initial-element 0)
+                            :offset 0
                             :total-size (array-total-size array)
                             :rank (length new-shape)
                             :root-array (if simple-dense-array-p
@@ -413,8 +411,7 @@ creating the new array and instead return a view instead. "
   (declare (type dense-array array))
   (let ((cl-array (cl:make-array (narray-dimensions array)
                                  :element-type (array-element-type array)
-                                 :initial-element (coerce 0 (array-element-type array))))
-        (index    0))
+                                 :initial-element (coerce 0 (array-element-type array)))))
     (dotimes (index (cl:array-total-size cl-array))
       (setf (cl:row-major-aref cl-array index)
             (row-major-aref array index)))

--- a/plus/magicl.lisp
+++ b/plus/magicl.lisp
@@ -50,7 +50,6 @@ If COPY is non-NIL, this copies over the underlying MAGICL::STORAGE"
          (layout       (magicl:layout magicl-tensor))
          (dimensions   (magicl:shape magicl-tensor))
          (strides      (dimensions->strides dimensions layout))
-         (offsets      (make-list rank :initial-element 0))
          (total-size   (magicl:size magicl-tensor)))
     (make-instance 'standard-dense-array
                    :layout layout
@@ -58,7 +57,7 @@ If COPY is non-NIL, this copies over the underlying MAGICL::STORAGE"
                    :rank rank
                    :dimensions dimensions
                    :strides strides
-                   :offsets offsets
+                   :offset 0
                    :total-size total-size
                    :storage storage
                    :root-array nil)))

--- a/src/dense-arrays.lisp
+++ b/src/dense-arrays.lisp
@@ -75,7 +75,7 @@
                      (layout *array-layout*)
 
                      (displaced-to nil displaced-to-p)
-                     (offset 0))
+                     (displaced-index-offset 0))
   "Like CL:MAKE-ARRAY but returns a DENSE-ARRAYS::DENSE-ARRAY instead of CL:ARRAY.
 Additionally takes
 
@@ -145,7 +145,7 @@ Additionally takes
                                          :element-type element-type
                                          :dimensions dimensions
                                          :strides strides
-                                         :offset offset
+                                         :offset displaced-index-offset
                                          :total-size (apply #'* dimensions)
                                          :root-array nil
                                          :rank (length dimensions)

--- a/src/dense-arrays.lisp
+++ b/src/dense-arrays.lisp
@@ -267,8 +267,7 @@ Additionally takes
 (defun array-displacement (array)
   "Returns two values:
 - ARRAY-STORAGE
-- OFFSET
-Consequences are undefined if ARRAY is displaced along multiple axis."
+- OFFSET"
   (declare (type dense-array array))
   (values (array-storage array)
           (array-offset array)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -58,7 +58,8 @@
              #:alexandria
              #:5am)
        (:export ,@shadow-symbols
-                ,@abstract-array-symbols)
+                ,@abstract-array-symbols
+                #:*print-tail-length*)
        (:shadow ,@shadow-symbols)
        (:shadowing-import-from #:cl #:ftype)
        (:shadowing-import-from #:peltadot

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -31,7 +31,6 @@
                              "ARRAY-DISPLACEMENT"
                              "ARRAY-DISPLACED-TO"
                              "ARRAY-OFFSET"
-                             "ARRAY-OFFSETS"
                              "ARRAY-STRIDE"
                              "ARRAY-STRIDES"
                              "ARRAY="

--- a/src/protocol.lisp
+++ b/src/protocol.lisp
@@ -10,7 +10,7 @@
   ;; For DENSE-ARRAY, this ELEMENT-TYPE depends on the underlying storage itself.
 
   ((strides      :required t :type list)
-   (offsets      :required t)
+   (offset       :required t :type size)
    (layout       :required t
                  ;; LAYOUT can be NIL in the case of a non SIMPLE-ARRAY
                  ;; LAYOUT will be ROW-MAJOR or COLUMN-MAJOR only for SIMPLE-ARRAY
@@ -19,7 +19,7 @@
   (:metaclass dense-array-class)
   (:documentation "- DIMENSIONS is a list of dimensions.
 - STRIDES is a list of strides along each dimension.
-- OFFSETS is a list of offsets along each dimension."))
+- OFFSET is the offset inside array-storage."))
 
 ;;; Below, we are using CLASS instead of CLASS-NAME because the CLASS objects
 ;;; will have a hierarchy, not the CLASS-NAMEs. This allows for partial specialization.


### PR DESCRIPTION
I implemented the idea mentioned in #14. I think this new approach is the correct way, because the old approach can't handle rank-0 array, and numpy also use this new approach (https://numpy.org/doc/stable/dev/internals.html). There's possibly also performance benefit because it saves a number of addition and list traversals. It also simplifies the logic in quite a few places so the code look cleaner. Take your time to review -- it's a quite big change!

It passes all tests that were passed before. There is a string asarray test in `dense-array-plus-lite`, which is also failed by the old version, fixing that should probably go in another patch.

Let me know your thoughts on this! Meanwhile I'll port `dense-numericals` as well.